### PR TITLE
defaults to fallback provider when no connected

### DIFF
--- a/src/context/web3Data/Web3Provider.jsx
+++ b/src/context/web3Data/Web3Provider.jsx
@@ -105,8 +105,10 @@ export function Web3Provider({ children }) {
   const load = useCallback(() => {
     if (web3Modal.cachedProvider) {
       connect();
+      return;
     }
-  }, [connect]);
+    connectDefaultProvider();
+  }, [connect, connectDefaultProvider]);
 
   useEffect(() => load(), [load]);
 


### PR DESCRIPTION
## Overview
Updated Web3Provider to connect to defaultProvider (fallback or local) on load when no cacheProvider. A missing update from last PR when adding a loading state